### PR TITLE
fix: RoleSessionName length

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -11,10 +11,12 @@ main() {
   local duration="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_IN_CURRENT_ACCOUNT_DURATION:-900}"
   local region="${BUILDKITE_PLUGIN_AWS_ASSUME_ROLE_IN_CURRENT_ACCOUNT_REGION:-""}"
   local buildnum="${BUILDKITE_BUILD_NUMBER:-unknown}"
+  local pipeline="${BUILDKITE_PIPELINE_NAME:-unknown}"
+  local session="bk-$pipeline-$buildnum"
 
   if [[ -n $role ]]; then
     echo "~~~ Assuming role $role ..."
-    assume_role "$role" "$buildnum" "$duration"
+    assume_role "$role" "$session" "$duration"
     if [[ -n $region ]]; then
       export AWS_REGION="$region"
       export AWS_DEFAULT_REGION="$region"


### PR DESCRIPTION
The first build in `rate-limiter-staging` failed because we use build number for session name, which is `1` and does not meet the required min length of 2 for this argument.

<img width="722" alt="image" src="https://github.com/gantry-ml/aws-assume-role-in-current-account-buildkite-plugin/assets/3219603/293267dd-611c-4fcf-8314-4c761281e40f">
